### PR TITLE
Add repository to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ license = "MIT"
 description = "A git subcommand to query and validate CODEOWNERS"
 version = "1.0.0"
 edition = "2021"
+repository = "https://github.com/chrisittner/git-owners"
 
 [dependencies]
 codeowners = "0.1.3"


### PR DESCRIPTION
It took me a bit of Googling to find this repo starting from https://crates.io, so I thought I'd add a link.